### PR TITLE
Refactor CoursesTableViewController

### DIFF
--- a/EarlyBird.xcodeproj/project.pbxproj
+++ b/EarlyBird.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		DC0215E21DBA49A600BDFC7D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DC0215E01DBA49A600BDFC7D /* LaunchScreen.storyboard */; };
 		DC0215ED1DBA49A600BDFC7D /* EarlyBirdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0215EC1DBA49A600BDFC7D /* EarlyBirdTests.swift */; };
 		DC0215F81DBA49A600BDFC7D /* EarlyBirdUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0215F71DBA49A600BDFC7D /* EarlyBirdUITests.swift */; };
+		DCF59A351DCA241D00DF36D8 /* Course.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF59A341DCA241D00DF36D8 /* Course.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +46,7 @@
 		DC0215F31DBA49A600BDFC7D /* EarlyBirdUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EarlyBirdUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC0215F71DBA49A600BDFC7D /* EarlyBirdUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarlyBirdUITests.swift; sourceTree = "<group>"; };
 		DC0215F91DBA49A600BDFC7D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DCF59A341DCA241D00DF36D8 /* Course.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Course.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +99,7 @@
 			children = (
 				DC0215D71DBA49A500BDFC7D /* AppDelegate.swift */,
 				DC0215D91DBA49A500BDFC7D /* CoursesTableViewController.swift */,
+				DCF59A341DCA241D00DF36D8 /* Course.swift */,
 				DC0215DE1DBA49A600BDFC7D /* Assets.xcassets */,
 				DC0215E01DBA49A600BDFC7D /* LaunchScreen.storyboard */,
 				DC0215E31DBA49A600BDFC7D /* Info.plist */,
@@ -255,6 +258,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DCF59A351DCA241D00DF36D8 /* Course.swift in Sources */,
 				DC0215DA1DBA49A500BDFC7D /* CoursesTableViewController.swift in Sources */,
 				DC0215D81DBA49A500BDFC7D /* AppDelegate.swift in Sources */,
 			);

--- a/EarlyBird/Course.swift
+++ b/EarlyBird/Course.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+class Course {
+    var ID: Int
+    var name: String
+    var street: String
+    var city: String
+    var state: String
+    var address: String { return "\(street), \(city), \(state)" }
+    var imageURL: URL
+    var phone: String
+    var webURL: URL { return URL(string: "https://early-bird-golf.herokuapp.com/courses/\(ID)")! }
+    
+    init(dictionary: [String: AnyObject]) {
+        self.ID = dictionary["id"]! as! Int
+        self.name = dictionary["name"]! as! String
+        self.street = dictionary["street"]! as! String
+        self.city = dictionary["city"]! as! String
+        self.state = dictionary["state"]! as! String
+        self.imageURL = URL(string: dictionary["image_path"]! as! String)!
+        self.phone = dictionary["phone"]! as! String
+    }
+}


### PR DESCRIPTION
This PR intends to accomplish the following: 
- Extract business logic from the CoursesTableViewController into the Course model.
- Change endpoint from `/courses/1` (individual course) to `/courses` (all courses) in CoursesTableViewController.
- Add `for in` loop to instantiate course objects with API course response data in CoursesTableViewController.
- Add detailTextLabel for course address in CoursesTableViewController (line 35).

Please inspect Course.swift (where I construct a course object).

Please inspect CoursesTableViewController.swift (where I refactored my endpoint, instantiate course objects, and display each course object's name and address in my UITableView).

My next step is to change line 12 of Course.swift (webURL).  I would like to direct the user to the log-in page, rather than the course show page.  This is because a user must be logged-in to book a tee time.  Please let me know if you have any suggestions on file structure, variable name clarity, or anything else.  Thanks!

If you would like to manually test, follow these steps:

Clone this branch

$cd EarlyBird

Make sure you have the most recent version of Xcode (click apple icon on the top left of your screen, click on App Store, and Update Xcode if needed).

$open EarlyBird.xcodeproj/

To run the App, click the play button on the top left of Xcode, or use the shortcut ⌘R

The iPhone simulator should appear with all golf courses displayed.

Click on a course

You should be directed to my Mod 3 App's course `show` page.

If you would like to book a tee time, you must click on the hamburger, sign in with Google, click on the hamburger, click on courses, click on desired tee time, select number of players, select name of players, and click book.  I have attempted to make adjust the styling to accommodate for mobile.

Below is an example of the App in action.

![EarlyBird](http://recordit.co/0n3etM9vZi.gif)